### PR TITLE
設定したブランチへのプルリクが正しく動作することを確認

### DIFF
--- a/JenkinsTest/JenkinsTest/Models/ModelTest.cs
+++ b/JenkinsTest/JenkinsTest/Models/ModelTest.cs
@@ -17,7 +17,9 @@ namespace JenkinsTest.Models
         [Test(Description ="NGをOKに修正のケース")]
         public void TestNG()
         {
- //           Assert.Fail();
+            // GitHub Pull Request Builder Pluginで、
+            // コミット&プッシュのケースを試してみる
+            //           Assert.Fail();
         }
     }
 }

--- a/JenkinsTest/JenkinsTest/Models/ModelTest.cs
+++ b/JenkinsTest/JenkinsTest/Models/ModelTest.cs
@@ -19,6 +19,7 @@ namespace JenkinsTest.Models
         {
             // GitHub Pull Request Builder Pluginで、
             // コミット&プッシュのケースを試してみる
+            // 再度
             //           Assert.Fail();
         }
     }


### PR DESCRIPTION
Jenkinsに、masterブランチ対象で設定。
developに対してプルリクを上げる。
想定：Jenkinsでのビルドが起動しない
